### PR TITLE
fix crash in vim application. 

### DIFF
--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -29,7 +29,7 @@ typedef IdentityFunction = Identity Function();
 typedef FingerprintCallback = bool Function(int, Uint8List);
 typedef ChannelCallback = void Function(Channel, Uint8List);
 typedef ChannelInputCallback = void Function(Channel, SerializableInput);
-typedef ResponseCallback = void Function(SSHTransport, String);
+typedef ResponseCallback = void Function(SSHTransport, Uint8List);
 typedef RemoteForwardCallback = Future<String> Function(
     Channel, String, int, String, int);
 


### PR DESCRIPTION
Application such as vim cause crash because of they send binary message instead of UTF-8 char stream. We can simply fix it by change decode method